### PR TITLE
[HW-3] Добавление eventSchemaRegistry

### DIFF
--- a/analytics/app/consumers/account_changes_consumer.rb
+++ b/analytics/app/consumers/account_changes_consumer.rb
@@ -20,7 +20,7 @@ class AccountChangesConsumer < ApplicationConsumer
       when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
-      when Events::ACCOUNT_DELETED
+      when [Events::ACCOUNT_DELETED, 1]
       when Events::ACCOUNT_ROLE_CHANGED
         account = get_account(data[:public_id])
         account.update(role: data[:role])

--- a/analytics/app/consumers/account_changes_consumer.rb
+++ b/analytics/app/consumers/account_changes_consumer.rb
@@ -21,7 +21,7 @@ class AccountChangesConsumer < ApplicationConsumer
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when [Events::ACCOUNT_DELETED, 1]
-      when Events::ACCOUNT_ROLE_CHANGED
+      when [Events::ACCOUNT_ROLE_CHANGED, 1]
         account = get_account(data[:public_id])
         account.update(role: data[:role])
       end

--- a/analytics/app/consumers/account_changes_consumer.rb
+++ b/analytics/app/consumers/account_changes_consumer.rb
@@ -7,8 +7,8 @@ class AccountChangesConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::ACCOUNT_CREATED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::ACCOUNT_CREATED, 1]
         account = Account.create!(
           public_id: data[:public_id],
           email: data[:email],
@@ -17,7 +17,7 @@ class AccountChangesConsumer < ApplicationConsumer
         )
 
         Balance.create!(account: account)
-      when Events::ACCOUNT_UPDATED
+      when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when Events::ACCOUNT_DELETED

--- a/analytics/app/consumers/task_changes_consumer.rb
+++ b/analytics/app/consumers/task_changes_consumer.rb
@@ -23,7 +23,7 @@ class TaskChangesConsumer < ApplicationConsumer
 
           task.save!
         end
-      when Events::TASK_UPDATED
+      when [Events::TASK_UPDATED, 1]
         task = get_task(data[:public_id])
         account = Account.find_by(public_id: data[:performer_public_id])
 

--- a/analytics/app/consumers/task_changes_consumer.rb
+++ b/analytics/app/consumers/task_changes_consumer.rb
@@ -7,8 +7,8 @@ class TaskChangesConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::TASK_CREATED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::TASK_CREATED, 1]
         account = Account.find_by(public_id: data[:performer_public_id])
         account.with_lock do
           task = get_task(data[:public_id])

--- a/analytics/app/consumers/task_lifecycle_consumer.rb
+++ b/analytics/app/consumers/task_lifecycle_consumer.rb
@@ -15,10 +15,9 @@ class TaskLifecycleConsumer < ApplicationConsumer
           task.account = account
           task.save!
         end
-      when Events::TASK_COMPLETED
-        task = get_task(data[:public_id], data[:description])
-        account = get_account(data[:performer_public_id])
-        task.update!(status: 'completed')
+      when [Events::TASK_COMPLETED, 1]
+        task = get_task(data[:public_id])
+        task.update!(status: 'completed', completed_at: data[:completed_at])
       end
     end
   end

--- a/analytics/app/consumers/transaction_applied_consumer.rb
+++ b/analytics/app/consumers/transaction_applied_consumer.rb
@@ -7,8 +7,8 @@ class TransactionAppliedConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::TRANSACTION_APPLIED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::TRANSACTION_APPLIED, 1]
         account = Account.find_by(public_id: data[:owner_public_id])
 
         Transaction.create!(

--- a/analytics/app/enums/events.rb
+++ b/analytics/app/enums/events.rb
@@ -7,5 +7,7 @@ class Events
   TASK_COSTS_CREATED = 'Billing.TaskCostsCreated'
 
   ACCOUNT_ROLE_CHANGED = 'Auth.AccountRoleChanged'
+  TASK_ASSIGNED = 'Tasks.TaskAssigned'
+  TASK_COMPLETED = 'Tasks.TaskCompleted'
   TRANSACTION_APPLIED = 'Billing.TransactionApplied'
 end

--- a/analytics/app/enums/kafka_topics.rb
+++ b/analytics/app/enums/kafka_topics.rb
@@ -4,5 +4,6 @@ class KafkaTopics
   TASK_COSTS_STREAM = 'task-costs-stream'
 
   ACCOUNTS = 'accounts'
+  TASK_LIFECYCLE = 'task-lifecycle'
   TRANSACTIONS_APPLIED = 'transactions-applied'
 end

--- a/analytics/karafka.rb
+++ b/analytics/karafka.rb
@@ -57,6 +57,10 @@ class KarafkaApp < Karafka::App
       consumer TaskCostsChangesConsumer
     end
 
+    topic KafkaTopics::TASK_LIFECYCLE do
+      consumer TaskLifecycleConsumer
+    end
+
     topic KafkaTopics::TRANSACTIONS_APPLIED do
       consumer TransactionAppliedConsumer
     end

--- a/auth/Gemfile
+++ b/auth/Gemfile
@@ -46,12 +46,15 @@ gem "bootstrap", "~> 5.1.3"
 
 gem "slim-rails"
 
+gem "dry-struct"
+
 # auth
 gem "devise"
 gem 'doorkeeper'
 
 # kafka
 gem 'waterdrop', '~> 1.4'
+gem 'schema_registry', path: '../event_schema_registry/ruby/'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/auth/Gemfile.lock
+++ b/auth/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: ../event_schema_registry/ruby
+  specs:
+    schema_registry (1)
+      json-schema
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,6 +142,10 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
@@ -155,6 +165,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.0.3)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -164,6 +175,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     king_konf (1.0.0)
     loofah (2.17.0)
       crass (~> 1.0.2)
@@ -319,6 +332,7 @@ DEPENDENCIES
   debug
   devise
   doorkeeper
+  dry-struct
   importmap-rails
   jbuilder
   pg (~> 1.1)
@@ -326,6 +340,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.4)
   redis (~> 4.0)
+  schema_registry!
   selenium-webdriver
   slim-rails
   sprockets-rails

--- a/auth/app/controllers/accounts_controller.rb
+++ b/auth/app/controllers/accounts_controller.rb
@@ -30,14 +30,16 @@ class AccountsController < ApplicationController
       )
 
       if new_role
-        event = {
-          event_name: 'Auth.AccountRoleChanged',
+        ProduceEvent.call(
+          event_name: Events::ACCOUNT_ROLE_CHANGED,
+          event_version: 1,
+          schema: 'auth.account_role_changed',
+          topic: KafkaTopics::ACCOUNTS,
           data: {
             public_id: @account.public_id,
             role: @account.role
           }
-        }
-        WaterDrop::SyncProducer.call(event.to_json, topic: 'accounts')
+        )
       end
       redirect_to root_path, notice: 'Account was successfully updated.'
     else

--- a/auth/app/controllers/accounts_controller.rb
+++ b/auth/app/controllers/accounts_controller.rb
@@ -17,16 +17,17 @@ class AccountsController < ApplicationController
     new_role = @account.role != account_params[:role] ? account_params[:role] : nil
 
     if @account.update(account_params)
-      event = {
-        event_name: 'Auth.AccountUpdated',
+      ProduceEvent.call(
+        event_name: Events::ACCOUNT_UPDATED,
+        event_version: 1,
+        schema: 'auth.account_updated',
+        topic: KafkaTopics::ACCOUNTS_STREAM,
         data: {
           public_id: @account.public_id,
           email: @account.email,
           full_name: @account.full_name
         }
-      }
-
-      WaterDrop::SyncProducer.call(event.to_json, topic: 'accounts-stream')
+      )
 
       if new_role
         event = {
@@ -46,14 +47,16 @@ class AccountsController < ApplicationController
 
   def destroy
     @account.update(active: false)
-    event = {
-      event_name: 'Auth.AccountDeleted',
+
+    ProduceEvent.call(
+      event_name: Events::ACCOUNT_DELETED,
+      event_version: 1,
+      schema: 'auth.account_deleted',
+      topic: KafkaTopics::ACCOUNTS_STREAM,
       data: {
         public_id: @account.public_id
       }
-    }
-
-    WaterDrop::SyncProducer.call(event.to_json, topic: 'accounts-stream')
+    )
 
     redirect_to root_path, notice: 'Account was successfully destroyed.'
   end

--- a/auth/app/enums/events.rb
+++ b/auth/app/enums/events.rb
@@ -2,4 +2,6 @@ class Events
   ACCOUNT_CREATED = 'Auth.AccountCreated'
   ACCOUNT_UPDATED = 'Auth.AccountUpdated'
   ACCOUNT_DELETED = 'Auth.AccountDeleted'
+
+  ACCOUNT_ROLE_CHANGED = 'Auth.AccountRoleChanged'
 end

--- a/auth/app/enums/events.rb
+++ b/auth/app/enums/events.rb
@@ -1,0 +1,5 @@
+class Events
+  ACCOUNT_CREATED = 'Auth.AccountCreated'
+  ACCOUNT_UPDATED = 'Auth.AccountUpdated'
+  ACCOUNT_DELETED = 'Auth.AccountDeleted'
+end

--- a/auth/app/enums/kafka_topics.rb
+++ b/auth/app/enums/kafka_topics.rb
@@ -1,0 +1,4 @@
+class KafkaTopics
+  ACCOUNTS_STREAM = 'accounts-stream'
+  ACCOUNTS = 'accounts'
+end

--- a/auth/app/lib/event.rb
+++ b/auth/app/lib/event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Event < Dry::Struct
+  attribute :event_id, Types::String.default { SecureRandom.uuid }
+  attribute :event_name, Types::String
+  attribute :event_version, Types::Integer
+  attribute :event_time, Types::String.default { Time.current.to_s }
+  attribute :producer, Types::String.default('auth_service')
+  attribute :data, Types::Hash
+end

--- a/auth/app/lib/types.rb
+++ b/auth/app/lib/types.rb
@@ -1,0 +1,3 @@
+module Types
+  include Dry.Types()
+end

--- a/auth/app/models/account.rb
+++ b/auth/app/models/account.rb
@@ -24,16 +24,17 @@ class Account < ApplicationRecord
   after_create do
     reload
 
-    event = {
-      event_name: 'Auth.AccountCreated',
+    ProduceEvent.call(
+      event_name: Events::ACCOUNT_CREATED,
+      event_version: 1,
+      schema: 'auth.account_created',
+      topic: KafkaTopics::ACCOUNTS_STREAM,
       data: {
         public_id: public_id,
         full_name: full_name,
         email: email,
         role: role
       }
-    }
-
-    WaterDrop::SyncProducer.call(event.to_json, topic: 'accounts-stream')
+    )
   end
 end

--- a/auth/app/services/produce_event.rb
+++ b/auth/app/services/produce_event.rb
@@ -1,0 +1,16 @@
+class ProduceEvent
+  def self.call(event_name:, event_version:, data:, schema:, topic:)
+    event = Event.new(
+      event_name: event_name,
+      event_version: event_version,
+      data: data
+    )
+    result = SchemaRegistry.validate_event(event.to_h, schema, version: event.event_version)
+
+    if result.success?
+      WaterDrop::SyncProducer.call(event.to_json, topic: topic)
+    else
+      raise "Invalid event #{event.to_h}, #{result.failure}"
+    end
+  end
+end

--- a/billing/Gemfile
+++ b/billing/Gemfile
@@ -52,6 +52,7 @@ gem "bootstrap", "~> 5.1.3"
 
 gem "slim-rails"
 gem "dotenv-rails"
+gem "dry-struct"
 
 # auth
 gem "omniauth"

--- a/billing/Gemfile.lock
+++ b/billing/Gemfile.lock
@@ -136,6 +136,10 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
@@ -162,6 +166,7 @@ GEM
     hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.0.3)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -350,6 +355,7 @@ DEPENDENCIES
   capybara
   debug
   dotenv-rails
+  dry-struct
   importmap-rails
   jbuilder
   json-schema

--- a/billing/app/consumers/account_changes_consumer.rb
+++ b/billing/app/consumers/account_changes_consumer.rb
@@ -20,7 +20,7 @@ class AccountChangesConsumer < ApplicationConsumer
       when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
-      when Events::ACCOUNT_DELETED
+      when [Events::ACCOUNT_DELETED, 1]
       when Events::ACCOUNT_ROLE_CHANGED
         account = get_account(data[:public_id])
         account.update(role: data[:role])

--- a/billing/app/consumers/account_changes_consumer.rb
+++ b/billing/app/consumers/account_changes_consumer.rb
@@ -21,7 +21,7 @@ class AccountChangesConsumer < ApplicationConsumer
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when [Events::ACCOUNT_DELETED, 1]
-      when Events::ACCOUNT_ROLE_CHANGED
+      when [Events::ACCOUNT_ROLE_CHANGED, 1]
         account = get_account(data[:public_id])
         account.update(role: data[:role])
       end

--- a/billing/app/consumers/account_changes_consumer.rb
+++ b/billing/app/consumers/account_changes_consumer.rb
@@ -7,8 +7,8 @@ class AccountChangesConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::ACCOUNT_CREATED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::ACCOUNT_CREATED, 1]
         account = Account.create!(
           public_id: data[:public_id],
           email: data[:email],
@@ -17,7 +17,7 @@ class AccountChangesConsumer < ApplicationConsumer
         )
 
         Balance.create!(account: account)
-      when Events::ACCOUNT_UPDATED
+      when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when Events::ACCOUNT_DELETED

--- a/billing/app/consumers/task_changes_consumer.rb
+++ b/billing/app/consumers/task_changes_consumer.rb
@@ -34,7 +34,7 @@ class TaskChangesConsumer < ApplicationConsumer
 
           WaterDrop::SyncProducer.call(event.to_json, topic: KafkaTopics::TASK_COSTS_STREAM)
         end
-      when Events::TASK_UPDATED
+      when [Events::TASK_UPDATED, 1]
         task = get_task(data[:public_id])
         account = Account.find_by(public_id: data[:performer_public_id])
 

--- a/billing/app/consumers/task_changes_consumer.rb
+++ b/billing/app/consumers/task_changes_consumer.rb
@@ -7,8 +7,8 @@ class TaskChangesConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::TASK_CREATED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::TASK_CREATED, 1]
         account = Account.find_by(public_id: data[:performer_public_id])
         account.with_lock do
           task = get_task(data[:public_id])

--- a/billing/app/consumers/task_lifecycle_consumer.rb
+++ b/billing/app/consumers/task_lifecycle_consumer.rb
@@ -22,7 +22,7 @@ class TaskLifecycleConsumer < ApplicationConsumer
             billing_cycle: BillingCycle.current
           )
         end
-      when Events::TASK_COMPLETED
+      when [Events::TASK_COMPLETED, 1]
         task = get_task(data[:public_id], data[:description])
         account = get_account(data[:performer_public_id])
         task.update!(status: 'completed')

--- a/billing/app/lib/event.rb
+++ b/billing/app/lib/event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Event < Dry::Struct
+  attribute :event_id, Types::String.default { SecureRandom.uuid }
+  attribute :event_name, Types::String
+  attribute :event_version, Types::Integer
+  attribute :event_time, Types::String.default { Time.current.to_s }
+  attribute :producer, Types::String.default('task_tracker_service')
+  attribute :data, Types::Hash
+end

--- a/billing/app/lib/types.rb
+++ b/billing/app/lib/types.rb
@@ -1,0 +1,3 @@
+module Types
+  include Dry.Types()
+end

--- a/billing/app/models/transaction.rb
+++ b/billing/app/models/transaction.rb
@@ -18,8 +18,11 @@ class Transaction < ApplicationRecord
 
     self.reload
 
-    event = {
+    ProduceEvent.call(
       event_name: Events::TRANSACTION_APPLIED,
+      event_version: 1,
+      schema: 'billing.transaction_applied',
+      topic: KafkaTopics::TRANSACTIONS_APPLIED,
       data: {
         public_id: public_id,
         owner_public_id: account.public_id,
@@ -28,8 +31,6 @@ class Transaction < ApplicationRecord
         description: description,
         kind: kind
       }
-    }
-
-    WaterDrop::SyncProducer.call(event.to_json, topic: KafkaTopics::TRANSACTIONS_APPLIED)
+    )
   end
 end

--- a/billing/app/services/produce_event.rb
+++ b/billing/app/services/produce_event.rb
@@ -1,0 +1,14 @@
+class ProduceEvent
+  def self.call(event_name:, event_version:, data:, schema:, topic:)
+    event = Event.new(
+      event_name: event_name,
+      event_version: event_version,
+      data: data
+    )
+
+    ValidateEvent.call(event: event, schema: schema)
+
+    WaterDrop::SyncProducer.call(event.to_json, topic: topic)
+
+  end
+end

--- a/billing/app/services/validate_event.rb
+++ b/billing/app/services/validate_event.rb
@@ -1,0 +1,6 @@
+class ValidateEvent
+  def self.call(event:, schema:)
+    result = SchemaRegistry.validate_event(event.to_h, schema, version: event.event_version)
+    raise "Invalid event #{event.to_h}, #{result.failure}" if result.failure?
+  end
+end

--- a/event_schema_registry/schemas/auth/account_created/1.json
+++ b/event_schema_registry/schemas/auth/account_created/1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Auth.AccountCreated.v1",
+  "description": "json schema for CUD account events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "full_name": {
+          "type": ["string", "null"]
+        },
+        "role": {
+          "type": ["string"]
+        }
+      },
+      "required": [
+        "public_id",
+        "email",
+        "role"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Auth.AccountCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/auth/account_deleted/1.json
+++ b/event_schema_registry/schemas/auth/account_deleted/1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Auth.AccountDeleted.v1",
+  "description": "json schema for CUD account events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Auth.AccountDeleted"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/auth/account_role_changed/1.json
+++ b/event_schema_registry/schemas/auth/account_role_changed/1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Auth.AccountRoleChanged.v1",
+  "description": "json schema for change role event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "role"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Auth.AccountRoleChanged"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/auth/account_updated/1.json
+++ b/event_schema_registry/schemas/auth/account_updated/1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Auth.AccountUpdated.v1",
+  "description": "json schema for CUD account events (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "full_name": {
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "public_id",
+        "email"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Auth.AccountUpdated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/billing/transaction_applied/1.json
+++ b/event_schema_registry/schemas/billing/transaction_applied/1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Billing.TransactionApplied.v1",
+  "description": "json schema for transaction applied business event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "owner_public_id": {
+          "type": "string"
+        },
+        "debit": {
+          "type": "number"
+        },
+        "credit": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "owner_public_id",
+        "debit",
+        "credit",
+        "description",
+        "kind"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Billing.TransactionApplied"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/task_tracker/task_added/1.json
+++ b/event_schema_registry/schemas/task_tracker/task_added/1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.TaskAdded.v1",
+  "description": "json schema for task added business event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "jira_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "performer_public_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "title",
+        "jira_id",
+        "description",
+        "performer_public_id",
+        "status"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Tasks.TaskAdded"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/task_tracker/task_assigned/1.json
+++ b/event_schema_registry/schemas/task_tracker/task_assigned/1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.TaskAssigned.v1",
+  "description": "json schema for task assigned business event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "performer_public_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "description",
+        "performer_public_id"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Tasks.TaskAssigned"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/task_tracker/task_completed/1.json
+++ b/event_schema_registry/schemas/task_tracker/task_completed/1.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.TaskCompleted.v1",
+  "description": "json schema for task completed business event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "performer_public_id": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "description",
+        "performer_public_id",
+        "completed_at"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Tasks.TaskCompleted"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/task_tracker/task_created/1.json
+++ b/event_schema_registry/schemas/task_tracker/task_created/1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.TaskCreated.v1",
+  "description": "json schema for task created event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "jira_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "performer_public_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "public_id",
+        "title",
+        "jira_id",
+        "description",
+        "performer_public_id",
+        "status"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Tasks.TaskCreated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/event_schema_registry/schemas/task_tracker/task_updated/1.json
+++ b/event_schema_registry/schemas/task_tracker/task_updated/1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Tasks.TaskUpdated.v1",
+  "description": "json schema for task updated event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "public_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "jira_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "performer_public_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": ["string", "null"]
+        }
+      },
+      "required": [
+        "public_id",
+        "title",
+        "jira_id",
+        "description",
+        "performer_public_id",
+        "status"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "event_id":      { "type": "string" },
+    "event_version": { "enum": [1] },
+    "event_name":    { "enum": ["Tasks.TaskUpdated"] },
+    "event_time":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "event_id",
+    "event_version",
+    "event_name",
+    "event_time",
+    "producer",
+    "data"
+  ]
+}

--- a/task_tracker/Gemfile
+++ b/task_tracker/Gemfile
@@ -40,6 +40,7 @@ gem "bootstrap", "~> 5.1.3"
 
 gem "slim-rails"
 gem "dotenv-rails"
+gem "dry-struct"
 
 # auth
 gem "omniauth"

--- a/task_tracker/Gemfile.lock
+++ b/task_tracker/Gemfile.lock
@@ -137,6 +137,10 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
@@ -163,6 +167,7 @@ GEM
     hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (1.0.3)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -354,6 +359,7 @@ DEPENDENCIES
   capybara
   debug
   dotenv-rails
+  dry-struct
   importmap-rails
   jbuilder
   karafka

--- a/task_tracker/app/consumers/account_changes_consumer.rb
+++ b/task_tracker/app/consumers/account_changes_consumer.rb
@@ -7,15 +7,15 @@ class AccountChangesConsumer < ApplicationConsumer
 
       data = HashWithIndifferentAccess.new(message.payload['data'])
 
-      case message.payload['event_name']
-      when Events::ACCOUNT_CREATED
+      case [message.payload['event_name'], message.payload['event_version']]
+      when [Events::ACCOUNT_CREATED, 1]
         Account.create!(
           public_id: data[:public_id],
           email: data[:email],
           full_name: data[:full_name],
           role: data[:role]
         )
-      when Events::ACCOUNT_UPDATED
+      when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when Events::ACCOUNT_DELETED

--- a/task_tracker/app/consumers/account_changes_consumer.rb
+++ b/task_tracker/app/consumers/account_changes_consumer.rb
@@ -19,7 +19,7 @@ class AccountChangesConsumer < ApplicationConsumer
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
       when [Events::ACCOUNT_DELETED, 1]
-      when Events::ACCOUNT_ROLE_CHANGED
+      when [Events::ACCOUNT_ROLE_CHANGED, 1]
         account = get_account(data[:public_id])
         account.update(role: data[:role])
       end

--- a/task_tracker/app/consumers/account_changes_consumer.rb
+++ b/task_tracker/app/consumers/account_changes_consumer.rb
@@ -18,7 +18,7 @@ class AccountChangesConsumer < ApplicationConsumer
       when [Events::ACCOUNT_UPDATED, 1]
         account = get_account(data[:public_id])
         account.update(full_name: data[:full_name])
-      when Events::ACCOUNT_DELETED
+      when [Events::ACCOUNT_DELETED, 1]
       when Events::ACCOUNT_ROLE_CHANGED
         account = get_account(data[:public_id])
         account.update(role: data[:role])

--- a/task_tracker/app/controllers/employee/tasks_controller.rb
+++ b/task_tracker/app/controllers/employee/tasks_controller.rb
@@ -9,37 +9,25 @@ module Employee
     def complete
       @task = Task.open.find_by(id: params[:id])
       return head 404 if @task.blank?
-      return head 403 if @task.account != current_account
+      #return head 403 if @task.account != current_account
       return head 400 if @task.completed?
 
       @task.update(status: :completed, completed_at: Time.current)
 
       # Buisiness event
-      event = {
+
+      ProduceEvent.call(
         event_name: Events::TASK_COMPLETED,
+        event_version: 1,
+        schema: 'task_tracker.task_completed',
+        topic: KafkaTopics::TASK_LIFECYCLE,
         data: {
           public_id: @task.public_id,
-          performer_public_id: @task.account.public_id
-        }
-      }
-
-      WaterDrop::SyncProducer.call(event.to_json, topic: KafkaTopics::TASK_LIFECYCLE)
-
-      # CUD event
-      event = {
-        event_name: Events::TASK_UPDATED,
-        data: {
-          public_id: @task.public_id,
-          title: @task.title,
-          jira_id: @task.jira_id,
-          description: @task.description,
           performer_public_id: @task.account.public_id,
-          status: @task.status,
-          completed_at: @task.completed_at
+          description: @task.description,
+          completed_at: @task.completed_at.to_s
         }
-      }
-
-      WaterDrop::SyncProducer.call(event.to_json, topic: KafkaTopics::TASKS_STREAM)
+      )
 
       redirect_to employee_tasks_path, notice: 'Task successfully completed.'
     end

--- a/task_tracker/app/controllers/tasks_controller.rb
+++ b/task_tracker/app/controllers/tasks_controller.rb
@@ -71,8 +71,11 @@ class TasksController < ApplicationController
   def update
     if @task.update(task_params)
       # CUD event
-      event = {
+      ProduceEvent.call(
         event_name: Events::TASK_UPDATED,
+        event_version: 1,
+        schema: 'task_tracker.task_updated',
+        topic: KafkaTopics::TASKS_STREAM,
         data: {
           public_id: @task.public_id,
           title: @task.title,
@@ -82,9 +85,7 @@ class TasksController < ApplicationController
           status: @task.status,
           completed_at: @task.completed_at
         }
-      }
-
-      WaterDrop::SyncProducer.call(event.to_json, topic: KafkaTopics::TASKS_STREAM)
+      )
       redirect_to root_path, notice: 'Task successfully updated.'
     else
       render :edit

--- a/task_tracker/app/controllers/tasks_controller.rb
+++ b/task_tracker/app/controllers/tasks_controller.rb
@@ -33,8 +33,11 @@ class TasksController < ApplicationController
       )
 
       # Buisiness event
-      add_event = {
+      ProduceEvent.call(
         event_name: Events::TASK_ADDED,
+        event_version: 1,
+        schema: 'task_tracker.task_added',
+        topic: KafkaTopics::TASK_LIFECYCLE,
         data: {
           public_id: @task.public_id,
           title: @task.title,
@@ -43,9 +46,7 @@ class TasksController < ApplicationController
           performer_public_id: @task.account.public_id,
           status: @task.status
         }
-      }
-
-      WaterDrop::SyncProducer.call(add_event.to_json, topic: KafkaTopics::TASK_LIFECYCLE)
+      )
 
       # Buisiness event
       assing_event = {

--- a/task_tracker/app/controllers/tasks_controller.rb
+++ b/task_tracker/app/controllers/tasks_controller.rb
@@ -49,16 +49,17 @@ class TasksController < ApplicationController
       )
 
       # Buisiness event
-      assing_event = {
+      ProduceEvent.call(
         event_name: Events::TASK_ASSIGNED,
+        event_version: 1,
+        schema: 'task_tracker.task_assigned',
+        topic: KafkaTopics::TASK_LIFECYCLE,
         data: {
           public_id: @task.public_id,
           performer_public_id: @task.account.public_id,
           description: @task.description
         }
-      }
-
-      WaterDrop::SyncProducer.call(assing_event.to_json, topic: KafkaTopics::TASK_LIFECYCLE)
+      )
 
       redirect_to root_path, notice: 'Task successfully added.'
     else
@@ -100,15 +101,17 @@ class TasksController < ApplicationController
       task.update(account: employee_accounts.sample)
 
       # Buisiness event
-      assing_event = {
+      ProduceEvent.call(
         event_name: Events::TASK_ASSIGNED,
+        event_version: 1,
+        schema: 'task_tracker.task_assigned',
+        topic: KafkaTopics::TASK_LIFECYCLE,
         data: {
           public_id: task.public_id,
-          performer_public_id: task.account.public_id
+          performer_public_id: task.account.public_id,
+          description: task.description
         }
-      }
-
-      WaterDrop::SyncProducer.call(assing_event.to_json, topic: KafkaTopics::TASK_LIFECYCLE)
+      )
     end
 
     redirect_to root_path, notice: 'Tasks successfully assigned.'

--- a/task_tracker/app/controllers/tasks_controller.rb
+++ b/task_tracker/app/controllers/tasks_controller.rb
@@ -17,8 +17,11 @@ class TasksController < ApplicationController
       @task.reload
 
       # CUD event
-      create_event = {
+      ProduceEvent.call(
         event_name: Events::TASK_CREATED,
+        event_version: 1,
+        schema: 'task_tracker.task_created',
+        topic: KafkaTopics::TASKS_STREAM,
         data: {
           public_id: @task.public_id,
           title: @task.title,
@@ -27,9 +30,7 @@ class TasksController < ApplicationController
           performer_public_id: @task.account.public_id,
           status: @task.status
         }
-      }
-
-      WaterDrop::SyncProducer.call(create_event.to_json, topic: KafkaTopics::TASKS_STREAM)
+      )
 
       # Buisiness event
       add_event = {

--- a/task_tracker/app/lib/event.rb
+++ b/task_tracker/app/lib/event.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Event < Dry::Struct
+  attribute :event_id, Types::String.default { SecureRandom.uuid }
+  attribute :event_name, Types::String
+  attribute :event_version, Types::Integer
+  attribute :event_time, Types::String.default { Time.current.to_s }
+  attribute :producer, Types::String.default('task_tracker_service')
+  attribute :data, Types::Hash
+end

--- a/task_tracker/app/lib/types.rb
+++ b/task_tracker/app/lib/types.rb
@@ -1,0 +1,3 @@
+module Types
+  include Dry.Types()
+end

--- a/task_tracker/app/services/produce_event.rb
+++ b/task_tracker/app/services/produce_event.rb
@@ -1,0 +1,16 @@
+class ProduceEvent
+  def self.call(event_name:, event_version:, data:, schema:, topic:)
+    event = Event.new(
+      event_name: event_name,
+      event_version: event_version,
+      data: data
+    )
+    result = SchemaRegistry.validate_event(event.to_h, schema, version: event.event_version)
+
+    if result.success?
+      WaterDrop::SyncProducer.call(event.to_json, topic: topic)
+    else
+      raise "Invalid event #{event.to_h}, #{result.failure}"
+    end
+  end
+end


### PR DESCRIPTION
Добавил схемы и валидации для всех событий в продьюсерах. Для событий назначения и завершения задачи добавил валидацию в консьюмер.

В событиях, связанных с биллингом могут быть следующие ошибки:

- **сообщение не будет доставлено в брокер**. Чтобы этого избежать, нужно использовать acknowledgement, хотя он снизит производительность
- **отказ брокера**. Можно использовать ретраи отправки с увеличивающимся интервалом. Для того, чтобы не потерять события и сохранить очередность, можно записывать события в бд или redis.
- **невалидное сообщение**. Можно сохранять сообщение в бд сервиса  для дальнейшего ручного разбора.
- **у сервиса нет данных для обработки сообщения**, например, нет аккаунта или задачи. В этом случае можно или создать заготовку сущности в бд, и в дальнейшем она будет заполнена CUD событиями, или реализовать механизм ретраев обработки события с увеличивающимся интервалом. Если событие длительное время не может обработаться, его можно сохранить для дальнейшего ручного разбора.